### PR TITLE
Fixes for non-Windows platforms

### DIFF
--- a/src/NClap/Metadata/ArgumentSetAttribute.cs
+++ b/src/NClap/Metadata/ArgumentSetAttribute.cs
@@ -151,23 +151,23 @@ namespace NClap.Metadata
                     break;
 
                 case ArgumentSetStyle.WindowsCommandLine:
-                    NamedArgumentPrefixes = new[] { "/", "-" };
-                    ShortNameArgumentPrefixes = new[] { "/", "-" };
-                    ArgumentValueSeparators = new[] { '=', ':' };
                     AllowNamedArgumentValueAsSucceedingToken = false;
                     AllowMultipleShortNamesInOneToken = false;
                     AllowElidingSeparatorAfterShortName = false;
                     NameGenerationFlags = ArgumentNameGenerationFlags.UseOriginalCodeSymbol;
+                    NamedArgumentPrefixes = new[] { "/", "-" };
+                    ShortNameArgumentPrefixes = new[] { "/", "-" };
+                    ArgumentValueSeparators = new[] { '=', ':' };
                     break;
 
                 case ArgumentSetStyle.PowerShell:
-                    NamedArgumentPrefixes = new[] { "-" };
-                    ShortNameArgumentPrefixes = new[] { "-" };
-                    ArgumentValueSeparators = new[] { ':' };
                     AllowNamedArgumentValueAsSucceedingToken = true;
                     AllowMultipleShortNamesInOneToken = false;
                     AllowElidingSeparatorAfterShortName = false;
                     NameGenerationFlags = ArgumentNameGenerationFlags.UseOriginalCodeSymbol;
+                    NamedArgumentPrefixes = new[] { "-" };
+                    ShortNameArgumentPrefixes = new[] { "-" };
+                    ArgumentValueSeparators = new[] { ':' };
                     break;
 
                 case ArgumentSetStyle.GetOpt:

--- a/src/NClap/Types/FileSystemPath.cs
+++ b/src/NClap/Types/FileSystemPath.cs
@@ -23,6 +23,11 @@ namespace NClap.Types
         /// path with respect to, if it's relative.</param>
         public FileSystemPath(string path, bool expandEnvironmentVariables, string rootPathForRelativePaths)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentOutOfRangeException(nameof(path));
+            }
+
             var pathToUse = expandEnvironmentVariables ? Environment.ExpandEnvironmentVariables(path) : path;
 
             Path = (rootPathForRelativePaths != null) ? GetFullPath(pathToUse, rootPathForRelativePaths) : pathToUse;

--- a/src/NClap/Utilities/InputUtilities.cs
+++ b/src/NClap/Utilities/InputUtilities.cs
@@ -152,7 +152,7 @@ namespace NClap.Utilities
                 case ConsoleKey.OemMinus:
                     return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '_' } : new[] { '-' };
                 case ConsoleKey.OemPlus:
-                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '=' } : new[] { '+' };
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '+' } : new[] { '=' };
                 case ConsoleKey.Oem1:
                     return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { ':' } : new[] { ';' };
                 case ConsoleKey.Oem2:

--- a/src/NClap/Utilities/InputUtilities.cs
+++ b/src/NClap/Utilities/InputUtilities.cs
@@ -58,6 +58,123 @@ namespace NClap.Utilities
         /// <returns>The characters.</returns>
         public static char[] GetChars(ConsoleKey key, ConsoleModifiers modifiers)
         {
+            //
+            // TODO: This whole method needs to be cleaned up.  We have
+            // existing code that is Windows-specific, which p/invokes
+            // into user32.dll to convert a ConsoleKey to an array of chars.
+            // Firstly, this definitely doesn't work on non-Windows platforms;
+            // secondly, it's not clear we need such a generic facility here
+            // anyhow.  Someone should look back into this to figure out what
+            // we *really* need, and find a way to provide that in a
+            // platform-agnostic way.
+            //
+
+#if NET461
+            return GetCharsOnWindows(key, modifiers);
+#else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return GetCharsOnWindows(key, modifiers);
+            }
+            else
+            {
+                return GetCharsOnAnyPlatform(key, modifiers);
+            }
+#endif
+        }
+
+        private static char[] GetCharsOnAnyPlatform(ConsoleKey key, ConsoleModifiers modifiers)
+        {
+            if (key >= ConsoleKey.A && key <= ConsoleKey.Z)
+            {
+                var alphaIndex = (int)key - (int)ConsoleKey.A;
+
+                char c;
+                if (modifiers.HasFlag(ConsoleModifiers.Control))
+                {
+                    c = (char)(alphaIndex + 1);
+                }
+                else
+                {
+                    c = (char)('a' + alphaIndex);
+                    if (modifiers.HasFlag(ConsoleModifiers.Shift))
+                    {
+                        c = char.ToUpper(c);
+                    }
+                }
+
+                return new[] { c };
+            }
+
+            if (key >= ConsoleKey.D0 && key <= ConsoleKey.D9)
+            {
+                char c;
+                if (modifiers.HasFlag(ConsoleModifiers.Shift))
+                {
+                    // TODO: This is plain wrong. It is dependent on keyboard layout.
+                    switch (key)
+                    {
+                        case ConsoleKey.D1: c = '!'; break;
+                        case ConsoleKey.D2: c = '@'; break;
+                        case ConsoleKey.D3: c = '#'; break;
+                        case ConsoleKey.D4: c = '$'; break;
+                        case ConsoleKey.D5: c = '%'; break;
+                        case ConsoleKey.D6: c = '^'; break;
+                        case ConsoleKey.D7: c = '&'; break;
+                        case ConsoleKey.D8: c = '*'; break;
+                        case ConsoleKey.D9: c = '('; break;
+                        case ConsoleKey.D0: c = ')'; break;
+                        default:
+                            return Array.Empty<char>();
+                    }
+                }
+                else
+                {
+                    var digitIndex = (int)key - (int)ConsoleKey.D0;
+                    c = (char)('0' + digitIndex);
+                }
+
+                return new[] { c };
+            }
+
+            switch (key)
+            {
+                case ConsoleKey.Spacebar:
+                    return new char[] { ' ' };
+
+                case ConsoleKey.Tab:
+                    return new char[] { '\t' };
+
+                case ConsoleKey.OemComma:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '<' } : new[] { ',' };
+                case ConsoleKey.OemPeriod:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '>' } : new[] { '.' };
+                case ConsoleKey.OemMinus:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '_' } : new[] { '-' };
+                case ConsoleKey.OemPlus:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '=' } : new[] { '+' };
+                case ConsoleKey.Oem1:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { ':' } : new[] { ';' };
+                case ConsoleKey.Oem2:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '?' } : new[] { '/' };
+                case ConsoleKey.Oem3:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '~' } : new[] { '`' };
+                case ConsoleKey.Oem4:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '{' } : new[] { '[' };
+                case ConsoleKey.Oem5:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '|' } : new[] { '\\' };
+                case ConsoleKey.Oem6:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '}' } : new[] { ']' };
+                case ConsoleKey.Oem7:
+                    return modifiers.HasFlag(ConsoleModifiers.Shift) ? new[] { '"' } : new[] { '\'' };
+
+                default:
+                    return Array.Empty<char>();
+            }
+        }
+
+        private static char[] GetCharsOnWindows(ConsoleKey key, ConsoleModifiers modifiers)
+        {
             var virtKey = (uint)key;
             var output = new char[32];
 

--- a/src/Tests/TestApp/CompleteCommand.cs
+++ b/src/Tests/TestApp/CompleteCommand.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using NClap.Metadata;
+using NClap.Types;
+
+namespace NClap.TestApp
+{
+    class CompleteCommand : SynchronousCommand
+    {
+        [NamedArgument]
+        public FileSystemPath Path { get; set; }
+
+        [NamedArgument]
+        public int Integer { get; set; }
+
+        [NamedArgument]
+        public string String { get; set; }
+
+        [NamedArgument]
+        public Guid Guid { get; set; }
+
+        [NamedArgument]
+        public bool Boolean { get; set; }
+
+        public override CommandResult Execute()
+        {
+            return CommandResult.Success;
+        }
+    }
+}

--- a/src/Tests/TestApp/MainCommandType.cs
+++ b/src/Tests/TestApp/MainCommandType.cs
@@ -11,6 +11,9 @@ namespace NClap.TestApp
         [Command(typeof(CliHelp), Description = "Displays toplevel help")]
         CliHelp,
 
+        [Command(typeof(CompleteCommand), Description = "Useful only for completing")]
+        Complete,
+
         [Command(typeof(ReadLineCommand), ShortName = "readl", Description = "Reads a line of input")]
         ReadLine,
 

--- a/src/Tests/TestApp/NClap.TestApp.csproj
+++ b/src/Tests/TestApp/NClap.TestApp.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp1.1;net461</TargetFrameworks>
-    <!--<RuntimeIdentifiers>win10-x64;ubuntu.16.04-x64</RuntimeIdentifiers>-->
-    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/Tests/TestApp/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/Tests/TestApp/Properties/PublishProfiles/FolderProfile.pubxml
@@ -8,7 +8,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <PublishDir>bin\$(Configuration)\PublishOutput</PublishDir>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <PublishDir>bin\Release\PublishOutput</PublishDir>
+    <RuntimeIdentifier>ubuntu.16.04-x64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/src/Tests/TestApp/Properties/launchSettings.json
+++ b/src/Tests/TestApp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NClap.TestApp": {
       "commandName": "Project",
-      "commandLineArgs": "repl -loglevle"
+      "commandLineArgs": "repl"
     }
   }
 }

--- a/src/Tests/UnitTests/Metadata/ArgumentAttributeTests.cs
+++ b/src/Tests/UnitTests/Metadata/ArgumentAttributeTests.cs
@@ -11,6 +11,7 @@ namespace NClap.Tests.Metadata
     [TestClass]
     public class ArgumentAttributeTests
     {
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class SimpleTestClass
         {
             [NamedArgument(HelpText = "My value")]

--- a/src/Tests/UnitTests/Metadata/ArgumentFlagsTests.cs
+++ b/src/Tests/UnitTests/Metadata/ArgumentFlagsTests.cs
@@ -13,30 +13,35 @@ namespace NClap.Tests.Metadata
     [TestClass]
     public class ArgumentFlagsTests
     {
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class RequiredArguments<T>
         {
             [NamedArgument(ArgumentFlags.Required)]
             public T Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class AtMostOnceArguments<T>
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public T Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class AtLeastOnceArguments<T>
         {
             [NamedArgument(ArgumentFlags.AtLeastOnce)]
             public T Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class MultipleArguments<T>
         {
             [NamedArgument(ArgumentFlags.Multiple)]
             public T Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class MultipleUniqueArguments<T>
         {
             [NamedArgument(ArgumentFlags.MultipleUnique)]

--- a/src/Tests/UnitTests/Metadata/ArgumentSetAttributeTests.cs
+++ b/src/Tests/UnitTests/Metadata/ArgumentSetAttributeTests.cs
@@ -12,21 +12,28 @@ namespace NClap.Tests.Metadata
     {
     #pragma warning disable 0649 // Field is never assigned to, and will always have its default value
 
-        [ArgumentSet(NamedArgumentPrefixes = new[] { "--" }, ShortNameArgumentPrefixes = new[] { ";" })]
+        [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
+            NamedArgumentPrefixes = new[] { "--" },
+            ShortNameArgumentPrefixes = new[] { ";" })]
         class AlternatePrefixArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public int Value;
         }
 
-        [ArgumentSet(ArgumentValueSeparators = new[] { '$' })]
+        [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
+            ArgumentValueSeparators = new[] { '$' })]
         class AlternateSeparatorArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public int Value;
         }
 
-        [ArgumentSet(AllowNamedArgumentValueAsSucceedingToken = true)]
+        [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
+            AllowNamedArgumentValueAsSucceedingToken = true)]
         class AllowArgumentValueAfterSpaceArguments
         {
             [NamedArgument]
@@ -37,6 +44,7 @@ namespace NClap.Tests.Metadata
         }
 
         [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
             NamedArgumentPrefixes = new[] { "--" },
             ShortNameArgumentPrefixes = new[] { "/" },
             AllowMultipleShortNamesInOneToken = true)]
@@ -53,6 +61,7 @@ namespace NClap.Tests.Metadata
         }
 
         [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
             NamedArgumentPrefixes = new[] { "--" },
             ShortNameArgumentPrefixes = new[] { "/" },
             AllowElidingSeparatorAfterShortName = true)]
@@ -62,7 +71,9 @@ namespace NClap.Tests.Metadata
             public int Value { get; set; }
         }
 
-        [ArgumentSet(NameGenerationFlags = ArgumentNameGenerationFlags.GenerateHyphenatedLowerCaseLongNames)]
+        [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
+            NameGenerationFlags = ArgumentNameGenerationFlags.GenerateHyphenatedLowerCaseLongNames)]
         class HyphenatedLongNamesArguments
         {
             [NamedArgument]
@@ -75,7 +86,10 @@ namespace NClap.Tests.Metadata
             SomeOtherValue
         }
 
-        [ArgumentSet(CaseSensitive = true, ShortNameArgumentPrefixes = new[] { "x" })]
+        [ArgumentSet(
+            Style = ArgumentSetStyle.WindowsCommandLine,
+            CaseSensitive = true,
+            ShortNameArgumentPrefixes = new[] { "x" })]
         class CaseSensitiveArguments
         {
             [NamedArgument(ShortName = "sF")]
@@ -304,7 +318,7 @@ namespace NClap.Tests.Metadata
         [TestMethod]
         public void CertainOptionsAreUnsupportedIfNamedArgPrefixesOverlap()
         {
-            var attrib = new ArgumentSetAttribute();
+            var attrib = new ArgumentSetAttribute { Style = ArgumentSetStyle.WindowsCommandLine };
             attrib.NamedArgumentPrefixes.Overlaps(attrib.ShortNameArgumentPrefixes).Should().BeTrue();
 
             Action a = () => attrib.AllowMultipleShortNamesInOneToken = true;

--- a/src/Tests/UnitTests/Metadata/ArgumentTests.cs
+++ b/src/Tests/UnitTests/Metadata/ArgumentTests.cs
@@ -13,12 +13,14 @@ namespace NClap.Tests.Metadata
     [TestClass]
     public class ArgumentTests
     {
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class StringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, AllowEmpty = true, ShortName = "v", DefaultValue = "def", Description = "Some value")]
             public string Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class StringArgumentsThatMustBeNonEmpty
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, AllowEmpty = false, DefaultValue = "")]
@@ -26,24 +28,28 @@ namespace NClap.Tests.Metadata
             public string Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class RestOfLineStringArguments
         {
             [PositionalArgument(ArgumentFlags.RestOfLine)]
             public string Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class KeyValuePairArguments
         {
             [NamedArgument(ArgumentFlags.Required, ShortName = "w")]
             public KeyValuePair<int, int> Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class StringArrayArguments
         {
             [NamedArgument(ArgumentFlags.Multiple, AllowEmpty = true, DefaultValue = new[] { "a", "b" })]
             public string[] Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class StringArrayWithEmptyDefaultArguments
         {
             [NamedArgument(ArgumentFlags.Multiple, AllowEmpty = true, DefaultValue = new string[] {})]
@@ -57,36 +63,42 @@ namespace NClap.Tests.Metadata
             Third
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class EnumArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public TestEnum Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class BoolArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public bool Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class BoolArgumentsWithTrueDefault
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = true)]
             public bool Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class EmptyLongNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, LongName = "")]
             public string Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class TupleOfIntAndStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public Tuple<int, string> Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class ArgumentsWithUnsettableDefault
         {
             public bool underlyingValue;
@@ -99,6 +111,7 @@ namespace NClap.Tests.Metadata
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class ArgumentsWithUnsettableCollectionDefault
         {
             public string[] underlyingValue;
@@ -111,6 +124,7 @@ namespace NClap.Tests.Metadata
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class DefaultedNamedArguments
         {
             [NamedArgument]
@@ -326,7 +340,11 @@ namespace NClap.Tests.Metadata
                 throw new NotSupportedException();
             }
 
-            return new ArgumentDefinition(mutableMemberInfo, attrib, setAttrib ?? new ArgumentSetAttribute(), options);
+            return new ArgumentDefinition(
+                mutableMemberInfo,
+                attrib,
+                setAttrib ?? new ArgumentSetAttribute { Style = ArgumentSetStyle.WindowsCommandLine },
+                options);
         }
     }
 }

--- a/src/Tests/UnitTests/Parser/AnswerFileParsingTests.cs
+++ b/src/Tests/UnitTests/Parser/AnswerFileParsingTests.cs
@@ -14,6 +14,7 @@ namespace NClap.Tests.Parser
     {
     #pragma warning disable 0649 // Field is never assigned to, and will always have its default value
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class Arguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -23,7 +24,7 @@ namespace NClap.Tests.Parser
             public string StringValue;
         }
         
-        [ArgumentSet(AnswerFileArgumentPrefix = "#!")]
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine, AnswerFileArgumentPrefix = "#!")]
         class AlternateSyntaxArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]

--- a/src/Tests/UnitTests/Parser/CommandLineParserTests.cs
+++ b/src/Tests/UnitTests/Parser/CommandLineParserTests.cs
@@ -27,11 +27,12 @@ namespace NClap.Tests.Parser
 
     #pragma warning disable 0649 // Field is never assigned to, and will always have its default value
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NoArguments
         {
         }
 
-        [ArgumentSet(Examples = new[] { "SimpleArgs /mu=4" })]
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine, Examples = new[] { "SimpleArgs /mu=4" })]
         class SimpleArguments : HelpArgumentsBase
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, Description = "Some boolean")]
@@ -71,72 +72,84 @@ namespace NClap.Tests.Parser
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class RequiredArguments : HelpArgumentsBase
         {
             [NamedArgument(ArgumentFlags.Required)]
             public string RequiredArgument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class RequiredPositionalArguments
         {
             [PositionalArgument(ArgumentFlags.Required)]
             public string RequiredArgument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class AllArgumentsAsArgumentString
         {
             [NamedArgument(ArgumentFlags.Required | ArgumentFlags.RestOfLine)]
             public string AllArguments;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class AllArgumentsAsPositionalArgumentString
         {
             [PositionalArgument(ArgumentFlags.Required | ArgumentFlags.RestOfLine)]
             public string AllArguments;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class AllArgumentsAsArray
         {
             [PositionalArgument(ArgumentFlags.Required | ArgumentFlags.RestOfLine)]
             public string[] AllArguments;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ArgumentsWithDefaultValue
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = 10)]
             public int Argument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ArgumentsWithCoerceableDefaultValue
         {
             [NamedArgument(DefaultValue = 1)]
             public uint Argument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ArgumentsWithDynamicDefaultValue
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = 10, DynamicDefaultValue = true)]
             public int Argument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class MultiplePositionalArguments
         {
             [PositionalArgument(ArgumentFlags.Multiple)]
             public string[] Args;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ReadOnlyFieldArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public readonly int Argument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ConstFieldArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public const int Argument = 7;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PrivateFieldArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, LongName = "argument")]
@@ -145,12 +158,14 @@ namespace NClap.Tests.Parser
             public int PrivateArgument => _argument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class StaticFieldArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public static int Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class DerivedArguments : SimpleArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, LongName = "DerivedMyString")]
@@ -163,17 +178,20 @@ namespace NClap.Tests.Parser
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         struct ValueTypeArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public int Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NoAttributedArguments
         {
             public int Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class OverriddenShortNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -183,12 +201,14 @@ namespace NClap.Tests.Parser
             public int OtherArgument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class EmptyShortNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, ShortName = "")]
             public int Argument;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class DuplicateLongNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, LongName = "Foo")]
@@ -198,6 +218,7 @@ namespace NClap.Tests.Parser
             public string Arg2;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NoAvailableShortNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -207,6 +228,7 @@ namespace NClap.Tests.Parser
             public int Foo;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class DuplicateShortNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, ShortName = "a")]
@@ -216,18 +238,21 @@ namespace NClap.Tests.Parser
             public int Argument2;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PropertyArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class UnsettablePropertyArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public int Value => 0;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class SamePositionArguments
         {
             [PositionalArgument(ArgumentFlags.AtMostOnce)]
@@ -237,12 +262,14 @@ namespace NClap.Tests.Parser
             public int Value2;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NoZeroPositionArguments
         {
             [PositionalArgument(ArgumentFlags.AtMostOnce, Position = 1)]
             public int Value1;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PositionPlusRestOfLineArguments<T>
         {
             [PositionalArgument(ArgumentFlags.AtMostOnce, Position = 0)]
@@ -252,6 +279,7 @@ namespace NClap.Tests.Parser
             public T RestOfLine;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NamedPlusRestOfLineArguments<T>
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -261,6 +289,7 @@ namespace NClap.Tests.Parser
             public T RestOfLine;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class RestOfLinePlusPositionArguments
         {
             [NamedArgument(ArgumentFlags.RestOfLine)]
@@ -270,6 +299,7 @@ namespace NClap.Tests.Parser
             public int Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class MultiplePositionalArgumentsPlusPositionArguments
         {
             [PositionalArgument(ArgumentFlags.Multiple)]
@@ -279,6 +309,7 @@ namespace NClap.Tests.Parser
             public int Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PositionalArguments
         {
             [PositionalArgument(ArgumentFlags.Required, Position = 1)]
@@ -288,31 +319,35 @@ namespace NClap.Tests.Parser
             public string Value0;
         }
 
-        [ArgumentSet(AdditionalHelp = "More help content.")]
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine, AdditionalHelp = "More help content.")]
         class AdditionalHelpArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
             public int Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ListArguments
         {
             [NamedArgument(ArgumentFlags.Multiple, LongName = "Value")]
             public List<string> Values;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class IListArguments
         {
             [NamedArgument(ArgumentFlags.Multiple, LongName = "Value")]
             public IList<string> Values;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ListPropertyArguments
         {
             [NamedArgument(ArgumentFlags.Multiple, LongName = "Value")]
             public List<string> Values { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class CustomPropertyArguments
         {
             private string _value;
@@ -333,6 +368,7 @@ namespace NClap.Tests.Parser
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PropertyWithoutGetArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -342,6 +378,7 @@ namespace NClap.Tests.Parser
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ThrowingStringPropertyArguments<TException> where TException : Exception, new()
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -352,6 +389,7 @@ namespace NClap.Tests.Parser
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ThrowingGuidPropertyArguments<TException> where TException : Exception, new()
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -362,12 +400,14 @@ namespace NClap.Tests.Parser
             }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class UnknownConflictingArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, ConflictsWith = new[] {"Foo"})]
             public string Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class SelfConflictingArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, ConflictsWith = new[] { nameof(Value) })]
@@ -377,6 +417,7 @@ namespace NClap.Tests.Parser
             public string OtherValue;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ConflictingArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, ConflictsWith = new[] { nameof(OtherValue) })]
@@ -386,6 +427,7 @@ namespace NClap.Tests.Parser
             public string OtherValue;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PartlySpecifiedConflictingArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, ConflictsWith = new[] { nameof(OtherValue) })]
@@ -395,18 +437,21 @@ namespace NClap.Tests.Parser
             public string OtherValue;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class FieldDefaultValueOfWrongTypeArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = "foo")]
             public long Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class PropertyDefaultValueOfWrongTypeArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = "foo")]
             public long Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class DefaultValueOfImplicitlyConvertibleTypeArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = 10)]
@@ -422,6 +467,7 @@ namespace NClap.Tests.Parser
             public FileSystemPath PathProp;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ZeroLengthLongNameArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, LongName = "")]
@@ -436,13 +482,14 @@ namespace NClap.Tests.Parser
             FlagTwo = 0x2
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class FlagEnumArguments
         {
             [NamedArgument(ArgumentFlags.Multiple)]
             public MyFlagsEnum Value;
         }
 
-        [ArgumentSet(PublicMembersAreNamedArguments = true)]
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine, PublicMembersAreNamedArguments = true)]
         class UnannotatedArguments
         {
             public string StringValue { get; set; }

--- a/src/Tests/UnitTests/Parser/TypeParsingTests.cs
+++ b/src/Tests/UnitTests/Parser/TypeParsingTests.cs
@@ -12,12 +12,14 @@ namespace NClap.Tests.Parser
     [TestClass]
     public class TypeParsingTests
     {
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class ArgumentsWithType<T>
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, AllowEmpty = true)]
             public T Value;
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         public class ArgumentsWithCollectionType<T>
         {
             [NamedArgument(ArgumentFlags.Multiple, LongName = "Value")]

--- a/src/Tests/UnitTests/Parser/ValidationTests.cs
+++ b/src/Tests/UnitTests/Parser/ValidationTests.cs
@@ -14,6 +14,7 @@ namespace NClap.Tests.Parser
     [TestClass]
     public class ValidationTests
     {
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class IncorrectlyUsedMustNotBeEmptyAttributeArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -21,6 +22,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class InvalidDefaultValueArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, DefaultValue = "")]
@@ -28,6 +30,7 @@ namespace NClap.Tests.Parser
             public string Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NonEmptyStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -39,6 +42,7 @@ namespace NClap.Tests.Parser
             public FileSystemPath Path { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NotValueIntArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -46,6 +50,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class MultiNotValueIntArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -53,6 +58,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NotValueStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -60,6 +66,7 @@ namespace NClap.Tests.Parser
             public string Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class RegExStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -67,6 +74,7 @@ namespace NClap.Tests.Parser
             public string Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NotRegExStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce, AllowEmpty = true)]
@@ -74,6 +82,7 @@ namespace NClap.Tests.Parser
             public string Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class CaseInsensitiveRegExStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -81,6 +90,7 @@ namespace NClap.Tests.Parser
             public string Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class GreaterThanArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -88,6 +98,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class GreaterThanOrEqualToArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -95,6 +106,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class LessThanArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -102,6 +114,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class LessThanOrEqualToArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -109,6 +122,7 @@ namespace NClap.Tests.Parser
             public int Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class FileExistsStringArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -116,6 +130,7 @@ namespace NClap.Tests.Parser
             public string Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class FileExistsArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -123,6 +138,7 @@ namespace NClap.Tests.Parser
             public FileSystemPath Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class DirectoryExistsArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -130,6 +146,7 @@ namespace NClap.Tests.Parser
             public FileSystemPath Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class ExistsArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]
@@ -137,6 +154,7 @@ namespace NClap.Tests.Parser
             public FileSystemPath Value { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class NotExistsArguments
         {
             [NamedArgument(ArgumentFlags.AtMostOnce)]

--- a/src/Tests/UnitTests/Parser/VerbParsingTests.cs
+++ b/src/Tests/UnitTests/Parser/VerbParsingTests.cs
@@ -39,6 +39,7 @@ namespace NClap.Tests.Parser
             public IReadOnlyDictionary<TCommandType, object> CommandArguments { get; set; }
         }
 
+        [ArgumentSet(Style = ArgumentSetStyle.WindowsCommandLine)]
         class SimpleArguments
         {
             [NamedArgument]

--- a/src/Tests/UnitTests/Types/FileSystemPathTests.cs
+++ b/src/Tests/UnitTests/Types/FileSystemPathTests.cs
@@ -11,10 +11,13 @@ namespace NClap.Tests.Types
     [TestClass]
     public class FileSystemPathTests
     {
+        private static string sampleRootPath =
+            Path.DirectorySeparatorChar == '/' ? "/root/sample" : @"h:\sample";
+
         [TestMethod]
         public void ImplicitConversionOfAbsolutePath()
         {
-            const string originalPath = @"r:\some\path";
+            var originalPath = sampleRootPath;
 
             FileSystemPath path = originalPath;
             path.OriginalPath.Should().Be(originalPath);
@@ -24,7 +27,7 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void ImplicitConversionOfRelativePath()
         {
-            const string originalPath = @"relative\path";
+            var originalPath = Path.Combine("relative", "path");
 
             FileSystemPath path = originalPath;
             path.OriginalPath.Should().Be(originalPath);
@@ -34,17 +37,19 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void ImplicitConversionBackToString()
         {
-            var path = new FileSystemPath(@"relative\path", false, @"c:\");
+            var path = new FileSystemPath(
+                Path.Combine("relative", "path"),
+                false,
+                sampleRootPath);
 
             string pathString = path;
-            pathString.Should().Be(@"c:\relative\path");
+            pathString.Should().Be(Path.Combine(sampleRootPath, "relative", "path"));
         }
 
         [TestMethod]
         public void ExplicitConversion()
         {
-            const string originalPath = @"c:\path";
-
+            var originalPath = sampleRootPath;
             var path = (FileSystemPath)originalPath;
             path.OriginalPath.Should().Be(originalPath);
             path.Path.Should().Be(originalPath);
@@ -53,7 +58,7 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void AsUsage()
         {
-            const string originalPath = @"c:\path";
+            var originalPath = sampleRootPath;
             var opaqueOriginalPath = (object)originalPath;
 
             var path = opaqueOriginalPath as FileSystemPath;
@@ -63,8 +68,8 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void AbsolutePathWithResolution()
         {
-            const string originalPath = @"c:\absolute\path";
-            const string rootPath = @"c:\foo";
+            var originalPath = Path.Combine(sampleRootPath, "somedir");
+            var rootPath = sampleRootPath;
 
             var path = new FileSystemPath(originalPath, false /* expand? */, rootPath);
             path.OriginalPath.Should().Be(originalPath);
@@ -74,8 +79,8 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void RelativePathWithResolution()
         {
-            const string originalPath = @"relative\path";
-            const string rootPath = @"c:\foo";
+            var originalPath = Path.Combine("relative", "path");
+            var rootPath = sampleRootPath;
 
             var path = new FileSystemPath(originalPath, false /* expand? */, rootPath);
             path.OriginalPath.Should().Be(originalPath);
@@ -85,6 +90,12 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void DriveRelativePathWithResolution()
         {
+            // This doesn't apply in all cases.
+            if (Path.DirectorySeparatorChar == '/')
+            {
+                return;
+            }
+
             const string originalPath = @"\relative\path";
             const string rootPath = @"c:\foo";
 
@@ -96,7 +107,7 @@ namespace NClap.Tests.Types
         [TestMethod]
         public void GetCompletionsWithInvalidContext()
         {
-            Action getCompletions = () => FileSystemPath.GetCompletions(null, @"h:\foo");
+            Action getCompletions = () => FileSystemPath.GetCompletions(null, sampleRootPath);
             getCompletions.ShouldThrow<ArgumentNullException>();
         }
 

--- a/src/Tests/UnitTests/Utilities/InputUtilitiesTests.cs
+++ b/src/Tests/UnitTests/Utilities/InputUtilitiesTests.cs
@@ -9,10 +9,76 @@ namespace NClap.Tests.Utilities
     public class InputUtilitiesTests
     {
         [TestMethod]
-        public void SimpleTest()
+        public void TestThatAlphaKeysTranslateCorrectly()
         {
-            InputUtilities.TryGetSingleChar(ConsoleKey.A, (ConsoleModifiers)0).Should().Be('a');
-            InputUtilities.TryGetSingleChar(ConsoleKey.A, ConsoleModifiers.Shift).Should().Be('A');
+            InputUtilities.TryGetSingleChar(ConsoleKey.E, (ConsoleModifiers)0).Should().Be('e');
+            InputUtilities.TryGetSingleChar(ConsoleKey.E, ConsoleModifiers.Shift).Should().Be('E');
+            InputUtilities.TryGetSingleChar(ConsoleKey.E, ConsoleModifiers.Control).Should().Be('\x05');
+        }
+
+        [TestMethod]
+        public void TestThatDigitKeysTranslateCorrectly()
+        {
+            InputUtilities.TryGetSingleChar(ConsoleKey.D3, (ConsoleModifiers)0).Should().Be('3');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.D0, ConsoleModifiers.Shift).Should().Be(')');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D1, ConsoleModifiers.Shift).Should().Be('!');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D2, ConsoleModifiers.Shift).Should().Be('@');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D3, ConsoleModifiers.Shift).Should().Be('#');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D4, ConsoleModifiers.Shift).Should().Be('$');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D5, ConsoleModifiers.Shift).Should().Be('%');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D6, ConsoleModifiers.Shift).Should().Be('^');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D7, ConsoleModifiers.Shift).Should().Be('&');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D8, ConsoleModifiers.Shift).Should().Be('*');
+            InputUtilities.TryGetSingleChar(ConsoleKey.D9, ConsoleModifiers.Shift).Should().Be('(');
+        }
+
+        [TestMethod]
+        public void TestThatWhitespaceKeysTranslateCorrectly()
+        {
+            InputUtilities.TryGetSingleChar(ConsoleKey.Spacebar, (ConsoleModifiers)0).Should().Be(' ');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Tab, (ConsoleModifiers)0).Should().Be('\t');
+        }
+
+        [TestMethod]
+        public void TestThatNamedOemKeysTranslateCorrectly()
+        {
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemComma, (ConsoleModifiers)0).Should().Be(',');
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemComma, ConsoleModifiers.Shift).Should().Be('<');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemMinus, (ConsoleModifiers)0).Should().Be('-');
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemMinus, ConsoleModifiers.Shift).Should().Be('_');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemPeriod, (ConsoleModifiers)0).Should().Be('.');
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemPeriod, ConsoleModifiers.Shift).Should().Be('>');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemPlus, (ConsoleModifiers)0).Should().Be('=');
+            InputUtilities.TryGetSingleChar(ConsoleKey.OemPlus, ConsoleModifiers.Shift).Should().Be('+');
+        }
+
+        [TestMethod]
+        public void TestThatNumberedOemKeysTranslateCorrectly()
+        {
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem1, (ConsoleModifiers)0).Should().Be(';');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem1, ConsoleModifiers.Shift).Should().Be(':');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem2, (ConsoleModifiers)0).Should().Be('/');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem2, ConsoleModifiers.Shift).Should().Be('?');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem3, (ConsoleModifiers)0).Should().Be('`');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem3, ConsoleModifiers.Shift).Should().Be('~');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem4, (ConsoleModifiers)0).Should().Be('[');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem4, ConsoleModifiers.Shift).Should().Be('{');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem5, (ConsoleModifiers)0).Should().Be('\\');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem5, ConsoleModifiers.Shift).Should().Be('|');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem6, (ConsoleModifiers)0).Should().Be(']');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem6, ConsoleModifiers.Shift).Should().Be('}');
+
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem7, (ConsoleModifiers)0).Should().Be('\'');
+            InputUtilities.TryGetSingleChar(ConsoleKey.Oem7, ConsoleModifiers.Shift).Should().Be('\"');
         }
     }
 }

--- a/src/Tests/UnitTests/Utilities/StringUtilitiesTests.cs
+++ b/src/Tests/UnitTests/Utilities/StringUtilitiesTests.cs
@@ -35,7 +35,7 @@ namespace NClap.Tests.Utilities
         {
             var builder = new StringBuilder();
             builder.AppendWrappedLine("hello", 80);
-            builder.ToString().Should().Be("hello\r\n");
+            builder.ToString().Should().Be("hello" + Environment.NewLine);
         }
 
         [TestMethod]
@@ -43,7 +43,7 @@ namespace NClap.Tests.Utilities
         {
             var builder = new StringBuilder();
             builder.AppendWrappedLine("hello", 3);
-            builder.ToString().Should().Be("hel\r\nlo\r\n");
+            builder.ToString().Should().Be("hel" + Environment.NewLine + "lo" + Environment.NewLine);
         }
 
         [TestMethod]
@@ -52,7 +52,7 @@ namespace NClap.Tests.Utilities
             var builder = new StringBuilder();
             builder.Append("PREFIX");
             builder.AppendWrappedLine("hello", 3);
-            builder.ToString().Should().Be("PREFIXhel\r\nlo\r\n");
+            builder.ToString().Should().Be("PREFIXhel" + Environment.NewLine + "lo" + Environment.NewLine);
         }
 
         [TestMethod]
@@ -60,7 +60,7 @@ namespace NClap.Tests.Utilities
         {
             var builder = new StringBuilder();
             builder.AppendWrappedLine("hello", 3, 2);
-            builder.ToString().Should().Be("  h\r\n  e\r\n  l\r\n  l\r\n  o\r\n");
+            builder.ToString().Should().Be("  h" + Environment.NewLine + "  e" + Environment.NewLine + "  l" + Environment.NewLine + "  l" + Environment.NewLine + "  o" + Environment.NewLine);
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace NClap.Tests.Utilities
         {
             var builder = new StringBuilder();
             builder.AppendWrappedLine("hello\n", 80);
-            builder.ToString().Should().Be("hello\r\n\r\n");
+            builder.ToString().Should().Be("hello" + Environment.NewLine + Environment.NewLine);
         }
 
         [TestMethod]
@@ -76,7 +76,7 @@ namespace NClap.Tests.Utilities
         {
             var builder = new StringBuilder();
             builder.AppendWrappedLine("hello\n\n\n", 80);
-            builder.ToString().Should().Be("hello\r\n\r\n\r\n\r\n");
+            builder.ToString().Should().Be("hello" + Environment.NewLine + Environment.NewLine + Environment.NewLine + Environment.NewLine);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace NClap.Tests.Utilities
         {
             var builder = new StringBuilder();
             builder.AppendWrappedLine("hello\nworld", 80, 4);
-            builder.ToString().Should().Be("    hello\r\n    world\r\n");
+            builder.ToString().Should().Be("    hello" + Environment.NewLine + "    world" + Environment.NewLine);
         }
 
         [TestMethod]
@@ -217,7 +217,7 @@ namespace NClap.Tests.Utilities
         [TestMethod]
         public void WrapWithEmptyLines()
         {
-            StringUtilities.Wrap("1234\r\n\r\n", 10, 4).Should().Be(
+            StringUtilities.Wrap("1234" + Environment.NewLine + Environment.NewLine, 10, 4).Should().Be(
                 "    1234" + Environment.NewLine +
                 "    "     + Environment.NewLine +
                 "    ");


### PR DESCRIPTION
These changes get our .NET Core tests passing on Windows + Ubuntu.  There's a set of changes to the tests themselves, which identify some bigger opportunities for cleaning up in the long term (i.e. too much dependence on the default style for argument sets).  There's also a small set of changes to the code-under-test to address missing functionality.

Once we get these tests passing, I'd suggest that we come back and clean up a bit -- to make this more maintainable for the future.