### PR TITLE
Documentation improvements, minor fix for CommandLineParser.Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,25 @@
 [![GitHub license](https://img.shields.io/github/license/reubeno/NClap.svg)](https://reubeno.github.io/NClap/LICENSE.txt)
 [![Code Coverage](https://codecov.io/gh/reubeno/NClap/branch/master/graph/badge.svg)](https://codecov.io/gh/reubeno/NClap) [![Join the chat at https://gitter.im/NClap/Lobby](https://badges.gitter.im/NClap/Lobby.svg)](https://gitter.im/NClap/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-NClap is a .NET library for parsing command-line arguments and building interactive
-command shells. It's driven by a declarative attribute syntax, and easy to extend.
-It's like a lightweight serializer for command-line arguments.
+NClap is a .NET library for parsing command-line arguments and building interactive command shells. It's driven by a declarative attribute syntax, and easy to extend. It's like a lightweight serializer for command-line arguments.
 
 ## Getting NClap
 
-The easiest way to consume NClap is by adding its [NuGet package](https://www.nuget.org/packages/NClap) to your project.
-It is built for use with .NET 4.6.1+ and .NET Core 1.1.
+The easiest way to consume NClap is by adding its [NuGet package](https://www.nuget.org/packages/NClap) to your project. It is built for use with .NET 4.6.1+ and .NET Core 1.1+.
 
 NClap is shared under the MIT license, as described in [LICENSE.txt](https://reubeno.github.io/NClap/LICENSE.txt).
 
 ## The details
 
 * [Basic usage](docs/Usage.md)
- 
 * [Mostly complete feature list](docs/Features.md)
 
 ## Contributing
 
-We welcome contributions of all kinds, whether it be submitting pull requests or even just
-filing issues or feature requests.
+We welcome contributions of all kinds, whether it be submitting pull requests or even just filing issues or feature requests!
 
-For code contributions, we follow the standard
-[Github workflow](https://guides.github.com/introduction/flow/).
+For code contributions, we follow the standard [Github workflow](https://guides.github.com/introduction/flow/).
 
 ## Code of conduct
 
-This project has adopted the
-[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the
-[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
-additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com] (mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -1,0 +1,104 @@
+# Commands
+
+Many command-line arguments are _data_; they enable or disable options, provide parameters, or something similar.  They're the nouns.  You often also need to let the user express which _actions_ they want your application to take.  We call these _commands_; they're the verbs.
+
+When specifying a command, a user often needs to specify command-specific parameters that might not apply to other commands, or might only apply to closely related commands.  There are also applications that find it helpful to group commands into a hierarchy, for easier discovery. NClap provides native support for each of these patterns, and does so in a way that allows the definition of individual commands to be as self-contained as you'd like, potentially supporting the sharing of reusable commands in multiple scenarios or applications.
+
+Okay, with that explained--now for some code!
+
+## Defining a command
+
+We'll start from the bottom.  Each command is an invokable action; it's represented by a class that implements the `ICommand` interface.  The interface is simple, containing a standard method that will be invoked when the command is executed. For flexibility, the execution is expected to be asynchronous, but you can have your command class inherit from a standard abstract class to simplify your implementation: `Command` for asynchronous commands and `SynchronousCommand` for commands that only support synchronous execution, e.g.:
+
+<!-- MdCompile: assembly=CommandExample, import=System -->
+```csharp
+using NClap.Metadata;
+
+class MyCoolCommand : SynchronousCommand
+{
+    [NamedArgument(ArgumentFlags.Required)]
+    public int MyValue { get; set; }
+
+    public override CommandResult Execute()
+    {
+        Console.WriteLine("Hello from my command: value = {MyValue}!");
+        return CommandResult.Success;
+    }
+}
+```
+
+Note above that you can use standard NClap attributes to add parameters to the command.  In this example, we have a required integer parameter that we can depend on in the `Execute` method.
+
+## Adding the command to your command line argument set
+
+The next step is to link this command definition into your application's command-line argument set. There's two steps here:
+
+1. Define an `enum` type that lists the possible commands that are mutually exclusive. 
+
+   For example, here we define an `enum` that allows the user to either execute `MyCoolCommand` or `MyLessCoolCommand`:
+
+<!-- MdCompile: assembly=CommandExample -->
+```csharp
+enum MyCommandType
+{
+    [Command(typeof(MyCoolCommand), LongName = "cool", Description = "Do the cool thing!")]
+    Cool,
+
+    [Command(typeof(MyLessCoolCommand), LongName = "notcool", Description = "Execute my significantly less cool command")]
+    LessCool
+}
+```
+
+Note the ability to use standard NClap argument options (e.g. `LongName` and `Description`) to customize how the different command choices may be indicated on the command line.  Here, the user should be able to type `cool` or `notcool` to select one of the commands.
+
+2. Add this group of commands to the main command-line argument set for the
+application:
+
+<!-- MdCompile: assembly=CommandExample -->
+```csharp
+class ProgramArguments
+{
+    [NamedArgument(ArgumentFlags.Optional)]
+    public bool Verbose { get; set; }
+
+    [PositionalArgument(ArgumentFlags.Required, Position = 0)]
+    public CommandGroup<MyCommandType> PrimaryCommand { get; set; }
+
+    // ...
+}
+```
+
+Note that we use standard NClap  attributes--`PositionalArgumentAttribute` in this case--to indicate where the command and all of its command-specific arguments will be spliced into the overall `ProramArguments`.
+
+## Invoking the command
+
+Once you've parsed your application's command-line arguments, you can easily execute whichever command was selected, e.g.:
+
+<!-- MdCompile: assembly=CommandExample, wrapinclass=true -->
+```csharp
+public static void Main(string[] args)
+{
+    ProgramArguments programArgs;
+    if (!CommandLineParser.TryParse(args, out programArgs))
+    {
+        return;
+    }
+
+    CommandResult result = programArgs.PrimaryCommand.Execute();
+
+    // ...
+}
+```
+
+## Exposing commands in an interactive loop
+
+Once you've defined your commands, you can also leverage them to create an interactive loop, with just a few extra lines of code:
+
+<!-- MdCompile: assembly=CommandExample, wrapinclass=true -->
+```csharp
+public static void RunLoop()
+{
+    var loop = new Loop(typeof(MyCommandType));
+    loop.Execute();
+}
+```

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,6 +1,6 @@
-## NClap Features
+# NClap Features
 
-### Command-line parsing
+## Command-line parsing
 
 NClap supports parsing most commonly used .NET types out of the box:
 
@@ -32,7 +32,7 @@ For all of these types, NClap supports:
 * Arguments parsed into fields or properties
 * Arguments parsed into public, internal, or private fields or properties
 
-### Interactive shells
+## Interactive shells
 
 NClap makes it easy to build an interactive shell and project actions into it as commands, with support for:
 
@@ -44,4 +44,3 @@ NClap makes it easy to build an interactive shell and project actions into it as
 * A custom partial implementation of `readline`
 * Auto-generated help command
 * Customizable keyboard bindings for input operations
-

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,125 +1,123 @@
-## Basic usage
+# Basic usage
 
-### Parsing command lines
+## Parsing command lines
 
 1. Define a type (`class` or `struct`) to describe the parsed arguments, e.g.:
 
-    <!-- MdCompile: assembly=ParseExample -->
-    ```csharp
-    using NClap.Metadata;
-    
-    class MyProgramArguments
+<!-- MdCompile: assembly=ParseExample -->
+```csharp
+using NClap.Metadata;
+
+class MyProgramArguments
+{
+    [NamedArgument]
+    public int ImportantValue { get; set; } // e.g.: ImportantValue=10
+}
+```
+
+Each field or property in the type decorated with a `NamedArgumentAttribute` or
+`PositionalArgumentAttribute` will be mapped to a named argument or positional argument, respectively.
+
+Alternatively, you can add an attribute to the type itself to indicate that all writable, public
+fields and properties should be mapped to optional named arguments:
+
+<!-- MdCompile: import=NClap.Metadata -->
+```csharp
+[ArgumentSet(PublicMembersAreNamedArguments = true)]
+class MyOtherProgramArguments
+{
+    // These will become optional, named parameters
+    public int MyAwesomeValue { get; set; }
+    public int MyOtherAwesomeValue { get; set; }
+}
+```
+
+You can customize the arguments through optional parameters to the attributes, e.g.:
+
+<!-- MdCompile: wrapinclass=true, import=NClap.Metadata -->
+```csharp
+[NamedArgument(ArgumentFlags.Required | ArgumentFlags.Multiple,
+                LongName = "ImpVal",
+                ShortName = "iv",
+                Description = "This is the very important value")]
+public int ImportantValue { get; set; }
+```
+
+In this above example, the C# property `ImportantValue` will be associated with
+a command-line option with two alternate names (`"ImpVal"` and `"iv"`). It must
+appear at least once on the command line, and may appear multiple times.
+
+2. Next, parse them!  You'll need to construct or otherwise acquire an instance of the target type that your arguments will be parsed into, and then call one of the static parser methods, e.g.:
+
+<!-- MdCompile: assembly=ParseExample, import=NClap -->
+```csharp
+using NClap;
+
+class MyProgram
+{
+    private static void Main(string[] args)
     {
-        [NamedArgument]
-        public int ImportantValue { get; set; } // e.g.: ImportantValue=10
-    }
-    ```
-
-    Each field or property in the type decorated with a `NamedArgumentAttribute` or
-    `PositionalArgumentAttribute` will be mapped to a named argument or positional argument, respectively.
-    
-    Alternatively, you can add an attribute to the type itself to indicate that all writable, public
-    fields and properties should be mapped to optional named arguments:
-    
-    <!-- MdCompile: import=NClap.Metadata -->
-    ```csharp
-    [ArgumentSet(PublicMembersAreNamedArguments = true)]
-    class MyOtherProgramArguments
-    {
-        // These will become optional, named parameters
-        public int MyAwesomeValue { get; set; }
-        public int MyOtherAwesomeValue { get; set; }
-    }
-    ```
-    
-    You can customize the arguments through optional parameters to the attributes, e.g.:
-
-    <!-- MdCompile: wrapinclass=true, import=NClap.Metadata -->
-    ```csharp
-    [NamedArgument(ArgumentFlags.Required | ArgumentFlags.Multiple,
-                   LongName = "ImpVal",
-                   ShortName = "iv",
-                   Description = "This is the very important value")]
-    public int ImportantValue { get; set; }
-    ```
-
-    In this above example, the C# property `ImportantValue` will be associated with
-    a command-line option with two alternate names (`"ImpVal"` and `"iv"`). It must
-    appear at least once on the command line, and may appear multiple times.
-
-2. Next, parse them!  You'll need to construct or otherwise acquire an instance of the target type that
-   your arguments will be parsed into, and then call one of the static parser methods, e.g.:
-
-    <!-- MdCompile: assembly=ParseExample, import=NClap -->
-    ```csharp
-    using NClap;
-    
-    class MyProgram
-    {
-        private static void Main(string[] args)
+        MyProgramArguments programArgs;
+        if (!CommandLineParser.TryParse(args, out programArgs))
         {
-			MyProgramArguments programArgs;
-            if (!CommandLineParser.TryParse(args, out programArgs))
-            {
-                return;
-            }
-
-            // TODO: Do something with the parsed args here...
+            return;
         }
+
+        // TODO: Do something with the parsed args here...
     }
-    ```
+}
+```
 
-    There are various overloads and variants of the parse methods (`CommandLineParser.Parse` and
-    `CommandLineParser.ParseWithUsage`).  The particular variant used here will automatically
-    display usage information to the console if an error occurred during argument parsing.
+There are various overloads and variants of the parse methods (`CommandLineParser.Parse` and
+`CommandLineParser.ParseWithUsage`).  The particular variant used here will automatically
+display usage information to the console if an error occurred during argument parsing.
 
-### Building an interactive shell
+## Building an interactive shell
 
 1. First, define the commands, or commands, that you want exposed into the shell, e.g.:
 
-    <!-- MdCompile: assembly=ShellExample, import=NClap.Repl, import=NClap.Metadata -->
-    ```csharp
-    enum MyCommandType
+<!-- MdCompile: assembly=ShellExample, import=NClap.Repl, import=NClap.Metadata -->
+```csharp
+enum MyCommandType
+{
+    [Command(typeof(ListCommand), Description = "Lists important things")]
+    ListImportantThings,
+
+    [Command(typeof(ExitCommand), Description = "Exits the shell")]
+    Exit
+}
+```
+
+Next, define the implementations of those commands, making sure to indicate any arguments to them, e.g.:
+
+<!-- MdCompile: assembly=ShellExample, import=System.Threading, import=System.Threading.Tasks, import=NClap.Metadata -->
+```csharp
+class ListCommand : Command
+{
+    [PositionalArgument(ArgumentFlags.Required, Position = 0, Description = "Type of things to list")]
+    public string ThingsType { get; set; }
+
+    public override Task<CommandResult> ExecuteAsync(CancellationToken cancel)
     {
-        [Command(typeof(ListCommand), Description = "Lists important things")]
-        ListImportantThings,
-
-        [Command(typeof(ExitCommand), Description = "Exits the shell")]
-        Exit
+        // TODO: Do something here.
+        return Task.FromResult(CommandResult.Success);
     }
-    ```
+}
+```
 
-    Next, define the implementations of those commands, making sure to indicate any arguments to them, e.g.:
+Finally, create the interactive shell and enter it:
 
-    <!-- MdCompile: assembly=ShellExample, import=System.Threading, import=System.Threading.Tasks, import=NClap.Metadata -->
-    ```csharp
-    class ListCommand : Command
-    {
-        [PositionalArgument(ArgumentFlags.Required, Position = 0, Description = "Type of things to list")]
-        public string ThingsType { get; set; }
+<!-- MdCompile: assembly=ShellExample, wrapinclass=true, import=NClap.Repl, import=System -->
+```csharp
+private static void RunInteractiveShell()
+{
+    Console.WriteLine("Entering loop...");
 
-        public override Task<CommandResult> ExecuteAsync(CancellationToken cancel)
-        {
-            // TODO: Do something here.
-            return Task.FromResult(CommandResult.Success);
-        }
-    }
-    ```
+    var loop = new Loop(typeof(MyCommandType));
+    loop.Execute();
 
-    Finally, create the interactive shell and enter it:
+    Console.WriteLine("Exited loop...");
+}
+```
 
-    <!-- MdCompile: assembly=ShellExample, wrapinclass=true, import=NClap.Repl, import=System -->
-    ```csharp
-    private static void RunInteractiveShell()
-    {
-        Console.WriteLine("Entering loop...");
-
-        var loop = new Loop(typeof(MyCommandType));
-        loop.Execute();
-
-        Console.WriteLine("Exited loop...");
-    }
-    ```
-
-    As with command-line argument parsing, there are many ways to further customize commands or the
-    shell itself.
+As with command-line argument parsing, there are many ways to further customize commands or the shell itself.

--- a/src/NClap.sln
+++ b/src/NClap.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27110.0
+VisualStudioVersion = 15.0.27128.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NClap", "NClap\NClap.csproj", "{C3ED7E97-9DB5-4035-A371-0D2B3DC3496D}"
 EndProject
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{56524B7F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{77079178-A7A6-422C-83B7-8C2449DC46BA}"
 	ProjectSection(SolutionItems) = preProject
+		..\docs\Commands.md = ..\docs\Commands.md
 		..\docs\Features.md = ..\docs\Features.md
 		..\LICENSE.txt = ..\LICENSE.txt
 		..\README.md = ..\README.md

--- a/src/NClap/CommandLineParser.cs
+++ b/src/NClap/CommandLineParser.cs
@@ -165,6 +165,20 @@ namespace NClap
         public static IEnumerable<string> Format<T>(T value)
         {
             var argSet = ReflectionBasedParser.CreateArgumentSet(typeof(T));
+            foreach (var arg in argSet.AllArguments.ToList())
+            {
+                if (arg.GetValue(value) is IArgumentProvider argProvider)
+                {
+                    var definingType = argProvider.GetTypeDefiningArguments();
+                    if (definingType != null)
+                    {
+                        ReflectionBasedParser.AddToArgumentSet(argSet, definingType,
+                            fixedDestination: argProvider.GetDestinationObject(),
+                            containingArgument: arg);
+                    }
+                }
+            }
+
             return argSet.AllArguments
                 .Select(arg => new { Argument = arg, Value = arg.GetValue(value) })
                 .Where(argAndValue => (argAndValue.Value != null) && !argAndValue.Value.Equals(argAndValue.Argument.DefaultValue))

--- a/src/NClap/Parser/ArgumentDefinition.cs
+++ b/src/NClap/Parser/ArgumentDefinition.cs
@@ -35,7 +35,7 @@ namespace NClap.Parser
             object defaultValue = null,
             ArgumentDefinition containingArgument = null) :
 
-            this(GetMutableMemberInfo(member), attribute, argSet, defaultValue, null)
+            this(GetMutableMemberInfo(member), attribute, argSet, defaultValue, /*fixedDestination=*/null, containingArgument)
         {
         }
 


### PR DESCRIPTION
Mostly focused on documenting basic usage of commands (see commands.md).