### PR TITLE
Fix string array argument parsing

### DIFF
--- a/src/NClap/Parser/ArgumentParser.cs
+++ b/src/NClap/Parser/ArgumentParser.cs
@@ -177,8 +177,11 @@ namespace NClap.Parser
 
             if (Argument.IsCollection)
             {
+                var newValues = Argument.CollectionArgumentType.ToEnumerable(newValue).Cast<object>();
+
                 // Check for disallowed duplicate values in this argument.
-                if (Argument.Unique && CollectionValues.Contains(newValue))
+                if (Argument.Unique &&
+                    CollectionValues.Cast<object>().Intersect(newValues).Any())
                 {
                     ReportDuplicateArgumentValue(value);
 
@@ -187,7 +190,10 @@ namespace NClap.Parser
                 }
 
                 // Add the value to the collection.
-                CollectionValues.Add(newValue);
+                foreach (var newValueItem in newValues)
+                {
+                    CollectionValues.Add(newValueItem);
+                }
             }
             else if (IsObjectPresent(DestinationObject))
             {
@@ -337,7 +343,7 @@ namespace NClap.Parser
 
         private bool ParseValue(string stringData, out object value)
         {
-            if (Argument.ValueType.TryParse(ParseContext, stringData, out value))
+            if (Argument.ArgumentType.TryParse(ParseContext, stringData, out value))
             {
                 return true;
             }

--- a/src/NClap/Types/CollectionOfTArgumentType.cs
+++ b/src/NClap/Types/CollectionOfTArgumentType.cs
@@ -73,7 +73,7 @@ namespace NClap.Types
         /// </summary>
         /// <param name="collection">Collection to enumerate.</param>
         /// <returns>The enumeration.</returns>
-        public override IEnumerable ToEnumerable(object collection) => (ICollection)collection;
+        public override IEnumerable ToEnumerable(object collection) => (IEnumerable)collection;
 
         /// <summary>
         /// Enumerates the objects contained within the provided collection;

--- a/src/Tests/UnitTests/Metadata/ArgumentTests.cs
+++ b/src/Tests/UnitTests/Metadata/ArgumentTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using FluentAssertions;
@@ -271,6 +272,20 @@ namespace NClap.Tests.Metadata
             var argSet = ReflectionBasedParser.CreateArgumentSet(typeof(ArgumentsWithUnsettableDefault));
             var state = new ArgumentParser(argSet, arg, new CommandLineParserOptions(), new ArgumentsWithUnsettableDefault());
             state.TryFinalize(FileSystemReader.Create()).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void StringArrayParsing()
+        {
+            var arg = GetArgument(typeof(StringArrayWithEmptyDefaultArguments));
+
+            var argSet = ReflectionBasedParser.CreateArgumentSet(typeof(StringArrayWithEmptyDefaultArguments));
+            var options = new CommandLineParserOptions();
+            var state = new ArgumentParser(argSet, arg, options, new StringArrayWithEmptyDefaultArguments());
+            var argSetParser = new ArgumentSetParser(argSet, options);
+            state.TryParseAndStore(argSetParser, "a,b,c", out var parsedValue).Should().BeTrue();
+            parsedValue.Should().BeAssignableTo<IEnumerable>();
+            (parsedValue as IEnumerable).Should().BeEquivalentTo(new[] { "a", "b", "c" });
         }
 
         [TestMethod]


### PR DESCRIPTION
The old behaviour is that the array element parser would have been used to parse the value -- and for strings that would return simply the list, but not as an array -- so you'd always get a single element back.

See the unit test for more information -- old behaviour of this unit test is that it fails because the parser returns a list with one element "a,b,c" instead of a list with three "a", "b", "c".
