### PR TITLE
Fix help message if a parameter is not recognized.

### DIFF
--- a/src/NClap/Parser/ArgumentSetParser.cs
+++ b/src/NClap/Parser/ArgumentSetParser.cs
@@ -672,10 +672,10 @@ namespace NClap.Parser
                     if (!string.IsNullOrEmpty(result.NamedArg))
                     {
                         var possibleArgs = GetSimilarNamedArguments(result.NamedArgType, result.NamedArg).ToList();
-                        if (possibleArgs.Count > 0)
+                        if (possibleArgs.Any())
                         {
                             ReportLine(
-                                "  " + Strings.PossibleIntendedNamedArguments,
+                                "  " + (possibleArgs.Count == 1 ? Strings.PossibleIntendedNamedArgument : Strings.PossibleIntendedNamedArguments),
                                 string.Join(", ", possibleArgs.Select(a => "'" + a + "'")));
                         }
                     }

--- a/src/NClap/Strings.Designer.cs
+++ b/src/NClap/Strings.Designer.cs
@@ -353,6 +353,15 @@ namespace NClap {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Did you mean {0}?.
+        /// </summary>
+        internal static string PossibleIntendedNamedArgument {
+            get {
+                return ResourceManager.GetString("PossibleIntendedNamedArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Did you mean one of: {0}?.
         /// </summary>
         internal static string PossibleIntendedNamedArguments {

--- a/src/NClap/Strings.Designer.cs
+++ b/src/NClap/Strings.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace NClap {
     using System;
-    
+    using System.Reflection;
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -39,7 +39,7 @@ namespace NClap {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NClap.Strings", typeof(Strings).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NClap.Strings", typeof(Strings).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/NClap/Strings.resx
+++ b/src/NClap/Strings.resx
@@ -216,6 +216,9 @@ Reason:
   <data name="PossibleArgumentValues" xml:space="preserve">
     <value>Possible argument values include: {0}.</value>
   </data>
+  <data name="PossibleIntendedNamedArgument" xml:space="preserve">
+    <value>Did you mean {0}?</value>
+  </data>
   <data name="PossibleIntendedNamedArguments" xml:space="preserve">
     <value>Did you mean one of: {0}?</value>
   </data>


### PR DESCRIPTION
Currently, if you enter an invalid parameter you get a message like:
- Did you mean one of: '-foo'?

This reads odd if you only have one suggestion. This fix amends the messaging so you get the above if there are multiple suggestions, but the following if you only have one suggestion:
- Did you mean '-foo'?

I also changed the ".Count > 0" to ".Any()" which is slightly more optimal.