### PR TITLE
Fix order of parameters in error

### DIFF
--- a/src/NClap/Parser/ArgumentParser.cs
+++ b/src/NClap/Parser/ArgumentParser.cs
@@ -373,7 +373,7 @@ namespace NClap.Parser
             ReportLine(Strings.DuplicateArgument, Argument.LongName, value);
 
         private void ReportConflictingArgument(string value, ArgumentDefinition conflictingArg) =>
-            ReportLine(Strings.ConflictingArgument, Argument.LongName, value, conflictingArg.LongName);
+            ReportLine(Strings.ConflictingArgument, value, Argument.LongName, conflictingArg.LongName);
 
         private void ReportBadArgumentValue(string value, ArgumentException exception) =>
             ReportBadArgumentValue(value, exception.Message);


### PR DESCRIPTION
Parameters being passed to Strings.ConflictingArgument were swapped; the value is supposed to be the first, followed by the argument name.  Could have equivalently changed the format string... but didn't.