### PR TITLE
Support prompt color in loop clients

### DIFF
--- a/src/NClap/PublicAPI.Unshipped.txt
+++ b/src/NClap/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ NClap.Help.ArgumentHelpOptions.IncludeNamedArgumentValueSyntax.set -> void
 NClap.Metadata.ArgumentSetAttribute.ExpandLogo.get -> bool
 NClap.Metadata.ArgumentSetAttribute.ExpandLogo.set -> void
 NClap.Parser.AttributeBasedArgumentDefinitionFactory
+NClap.Repl.ILoopClient.PromptWithColor.get -> NClap.Utilities.ColoredString?
+NClap.Repl.ILoopClient.PromptWithColor.set -> void
 NClap.Types.IArgumentValue.GetAttributes<T>() -> System.Collections.Generic.IEnumerable<T>
 static NClap.Help.ArgumentSetHelpOptionsExtensions.NoDescription(this NClap.Utilities.FluentBuilder<NClap.Help.ArgumentSetHelpOptions> builder) -> NClap.Utilities.FluentBuilder<NClap.Help.ArgumentSetHelpOptions>
 static NClap.Help.ArgumentSetHelpOptionsExtensions.NoEnumValues(this NClap.Utilities.FluentBuilder<NClap.Help.ArgumentSetHelpOptions> builder) -> NClap.Utilities.FluentBuilder<NClap.Help.ArgumentSetHelpOptions>

--- a/src/NClap/Repl/ConsoleLoopClient.cs
+++ b/src/NClap/Repl/ConsoleLoopClient.cs
@@ -32,6 +32,15 @@ namespace NClap.Repl
         }
 
         /// <summary>
+        /// The loop prompt (with color).
+        /// </summary>
+        public ColoredString? PromptWithColor
+        {
+            get => Reader.LineInput.Prompt;
+            set => Reader.LineInput.Prompt = value.GetValueOrDefault(ColoredString.Empty);
+        }
+
+        /// <summary>
         /// The character that starts a comment.
         /// </summary>
         public char? EndOfLineCommentCharacter { get; set; }

--- a/src/NClap/Repl/ILoopClient.cs
+++ b/src/NClap/Repl/ILoopClient.cs
@@ -1,4 +1,5 @@
 ﻿using NClap.ConsoleInput;
+using NClap.Utilities;
 
 namespace NClap.Repl
 {
@@ -8,9 +9,15 @@ namespace NClap.Repl
     public interface ILoopClient
     {
         /// <summary>
-        /// The loop prompt.
+        /// The loop prompt. If you wish to use a <see cref="ColoredString"/> as your
+        /// prompt, you should use the <see cref="PromptWithColor"/> property instead.
         /// </summary>
         string Prompt { get; set; }
+
+        /// <summary>
+        /// The loop prompt (with color).
+        /// </summary>
+        ColoredString? PromptWithColor { get; set; }
 
         /// <summary>
         /// The character that starts a comment.

--- a/src/Tests/UnitTests/Repl/ConsoleLoopClientTests.cs
+++ b/src/Tests/UnitTests/Repl/ConsoleLoopClientTests.cs
@@ -92,6 +92,30 @@ namespace NClap.Tests.Repl
         }
 
         [TestMethod]
+        public void TestThatColoredPromptsAreObserved()
+        {
+            var prompt = new ColoredString("[Prompt!] ", ConsoleColor.Cyan);
+
+            var reader = Substitute.For<IConsoleReader>();
+            var lineInput = Substitute.For<IConsoleLineInput>();
+
+            lineInput.Prompt = prompt;
+            reader.LineInput.Returns(lineInput);
+
+            var client = new ConsoleLoopClient(reader);
+            client.Prompt.Should().Be(prompt);
+
+            var newPrompt = new ColoredString("NewPrompt", ConsoleColor.Green);
+            client.PromptWithColor = newPrompt;
+            client.PromptWithColor.Should().Be(newPrompt);
+            client.Prompt.Should().Be(newPrompt.ToString());
+            lineInput.Prompt.Should().Be(newPrompt);
+
+            client.DisplayPrompt();
+            lineInput.Received(1).DisplayPrompt();
+        }
+
+        [TestMethod]
         public void TestThatReadLineWorksAsExpected()
         {
             const string lineText = "The line that was read.";


### PR DESCRIPTION
This is a fix for #67.  To avoid making a breaking change, we're adding a new property called `PromptWithColor` to `ILoopClient` and its stock implementation.  In the future, if we ever do make a wave of breaking changes, we can coalesce this with the existing `string Prompt` property.