### PR TITLE
Fix blocking issue on mono

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,17 @@ jobs:
       - name: "Package (release)"
         run: dotnet pack src/NClap.sln --no-build --no-restore -c Release
 
+      - name: "Install: mono"
+        run: |
+          sudo apt install -y gnupg ca-certificates
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt update
+          sudo apt install -y mono-devel
+
+      - name: "Test: .NET Framework 4.6.1 (via mono)"
+        run: dotnet test src/Tests/UnitTests/bin/Release/net461/NClap.Tests.dll
+
       - name: "Test: .NET Core 3.1"
         run: dotnet test src/NClap.sln --no-build --no-restore -c Release --verbosity normal -f netcoreapp3.1
 

--- a/src/NClap/Types/ArgumentType.cs
+++ b/src/NClap/Types/ArgumentType.cs
@@ -174,7 +174,7 @@ namespace NClap.Types
         /// </summary>
         public static IArgumentType Single => Float;
 
-        private static readonly Dictionary<Guid, IArgumentType> BuiltInTypes = new Dictionary<Guid, IArgumentType>();
+        private static readonly Dictionary<string, IArgumentType> BuiltInTypes = new Dictionary<string, IArgumentType>();
 
         /// <summary>
         /// Static constructor, responsible for internally registering all
@@ -213,7 +213,7 @@ namespace NClap.Types
 
             foreach (var type in types)
             {
-                BuiltInTypes.Add(type.Type.GetTypeInfo().GUID, type);
+                BuiltInTypes.Add(type.Type.GetTypeInfo().AssemblyQualifiedName, type);
             }
         }
 
@@ -332,6 +332,6 @@ namespace NClap.Types
         }
 
         private static bool TryGetBuiltInType(Type type, out IArgumentType argType) =>
-            BuiltInTypes.TryGetValue(type.GetTypeInfo().GUID, out argType);
+            BuiltInTypes.TryGetValue(type.GetTypeInfo().AssemblyQualifiedName, out argType);
     }
 }


### PR DESCRIPTION
Uses assembly-qualified name of types instead of `GUID`s. The latter appear not to be populated in Mono for built-in types.

Updates pipeline to run 4.6.1-based unit tests on mono.

Closes #85 