### PR TITLE
Exception in help command with CommandGroup fix

### DIFF
--- a/src/NClap/Metadata/CommandGroup`1.cs
+++ b/src/NClap/Metadata/CommandGroup`1.cs
@@ -87,7 +87,7 @@ namespace NClap.Metadata
         [PositionalArgument(ArgumentFlags.Required, Position = 0, LongName = nameof(Command))]
         public TCommandType? Selection
         {
-            get => (TCommandType)SelectedCommand;
+            get => (TCommandType?)SelectedCommand;
             set => SelectedCommand = value.HasValue ? (object)value.Value : null;
         }
 


### PR DESCRIPTION
This little patch fixes crashes when executing Help command against CommandGroup. This is mentioned here also: https://github.com/reubeno/NClap/issues/147